### PR TITLE
Don't run GCLH on advertisement iframes

### DIFF
--- a/gc_little_helper.user.js
+++ b/gc_little_helper.user.js
@@ -25,7 +25,7 @@
 // @grant          GM_registerMenuCommand
 // ==/UserScript==
 
-if(window.name == '' || window.name == 'gclhFrame') {  // don't run on advertisement iframes
+if(window.name.substring(0, 18) != 'google_ads_iframe_') {  // don't run on advertisement iframes
 
 var operaHelperInitComplete = false;
 var operaHelperDomLoaded = false;


### PR DESCRIPTION
On Firefox, for some reason, GCLH runs on the main window and also on each (i-)frame. This includes: Goodle ads, inline logging, and ads on the inline logging page. Hence, GCLH runs 2 or even 4 times per page.

This fix corrects this behavior such that GCLH runs only once, or twice with inline logging enabled. I've tested it on Firefox, Chrome, and Opera.
