### PR TITLE
Fix: New markdown-layout in logs

### DIFF
--- a/gc_little_helper.user.js
+++ b/gc_little_helper.user.js
@@ -5150,7 +5150,7 @@ var mainGC = function () {
         '                        <img title="${LogType}" alt="${LogType}" src="/images/logtypes/${LogTypeImage}">&nbsp;${LogType}</strong></div>' +
         '                <div class="HalfRight AlignRight">' +
         '                    <span class="minorDetails LogDate">${Visited}</span></div>' +
-        '                <div class="Clear LogContent">' +
+        '                <div class="Clear LogContent markdown-output">' +
         '                    {{if LatLonString.length > 0}}' +
         '                    <strong>${LatLonString}</strong>' +
         '                    {{/if}}' +


### PR DESCRIPTION
If the logs are loaded by GCLittleHelper than new markdown layout are not displayed.
This was fixed here.